### PR TITLE
Updated enums to avoid deprecation warnings from Moose >= 2.1200

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Barcode-DataMatrix
+0.05    Thu Apr 16 09:56:07 CDT 2015
+        - Updated the various enums to use an array reference rather
+          than an array to avoid deprecation warnings when using Moose 2.1200
+          or newer
 
 0.04    Thu Jun 21 09:01:05 CDT 2012
         - Use Module::Install::Repository because metacpan doesn't

--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -3,12 +3,12 @@ use Any::Moose;
 use Any::Moose '::Util::TypeConstraints';
 use Barcode::DataMatrix::Engine ();
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 has 'encoding_mode' => (
     is       => 'ro',
-    isa      => enum(qw[ ASCII C40 TEXT BASE256 NONE AUTO ]),
-    isa      => enum('BCDM_EncodingMode', qw[ ASCII C40 TEXT BASE256 NONE AUTO ]),
+    isa      => enum([qw[ ASCII C40 TEXT BASE256 NONE AUTO ]]),
+    isa      => enum('BCDM_EncodingMode', [qw[ ASCII C40 TEXT BASE256 NONE AUTO ]]),
     required => 1,
     default  => 'AUTO',
     documentation => 'The encoding mode for the data matrix. Can be one of: ASCII C40 TEXT BASE256 NONE AUTO',


### PR DESCRIPTION
Updated the enums to avoid the deprecation warnings when used on a system with Moose version 2.1200 or higher

See the release notes at this [link](https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#The-non-arrayref-forms-of-enum-and-duck_type-have-been-deprecated)