### PR TITLE
Update copyright to year of current release

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ ATTRIBUTES
     recognize special characters. See this page for more information:
     http://www.idautomation.com/datamatrixfaq.html
 
-AUTHOR
+AUTHORS
     Mons Anderson `<inthrax@gmail.com>' (GD::Barcode::DataMatrix at
     http://code.google.com/p/perl-ex/, from which this distribution
     originates)
@@ -55,7 +55,7 @@ SEE ALSO
     http://www.idautomation.com/datamatrixfaq.html
 
 LICENSE AND COPYRIGHT
-    Copyright 2011 the AUTHORs listed above.
+    Copyright 2015 the AUTHORS listed above.
 
     This program is free software; you can redistribute it and/or modify it
     under the terms of either: the GNU General Public License as published

--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -103,7 +103,7 @@ L<http://www.idautomation.com/datamatrixfaq.html>
 
 =cut
 
-=head1 AUTHOR
+=head1 AUTHORS
 
 Mons Anderson C<< <inthrax@gmail.com> >> (GD::Barcode::DataMatrix at L<http://code.google.com/p/perl-ex/>, from which this distribution originates)
 
@@ -127,7 +127,7 @@ L<http://github.com/mstratman/Barcode-DataMatrix>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2011 the AUTHORs listed above.
+Copyright 2015 the AUTHORS listed above.
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published


### PR DESCRIPTION
At the same time making the AUTHORS section of the docs plural and updating
the text in the copyright statement appropriately for this.

This pull request is submitted in the hope that it is useful.  Any questions and/or comments concerning it are more than welcome.