### PR TITLE
Skip POD tests in normal test suite

### DIFF
--- a/xt/pod-coverage.t
+++ b/xt/pod-coverage.t
@@ -2,6 +2,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;
 eval "use Test::Pod::Coverage $min_tpc";

--- a/xt/pod.t
+++ b/xt/pod.t
@@ -4,6 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";


### PR DESCRIPTION
The POD tests should only be run as part of the author tests (they're in the
`xt` directory).  This change allows `make test` to pass even when
`Test::Pod` and friends are installed.

This pull request is submitted in the hope that it is useful.  Any questions and comments are more than welcome!