### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.travis.yml
 !.gitignore
 Makefile*
 !Makefile.PL

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Module::Install::Repository Module::Install::AuthorTests
+    - PERL_MM_USE_DEFAULT=1 cpanm --installdeps .


### PR DESCRIPTION
Travis-CI (http://travis-ci.org) is a free (for open source projects)
continuous integration service.  This change adds the required configuration
file; one merely needs to set up Travis integration with GitHub to check all
pushes to the repository.