### PR TITLE
Add missing strictures

### DIFF
--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -3,6 +3,7 @@ use Any::Moose;
 use Any::Moose '::Util::TypeConstraints';
 use Barcode::DataMatrix::Engine ();
 
+## no critic (RequireUseWarnings, RequireUseStrict)
 our $VERSION = '0.05';
 
 has 'encoding_mode' => (

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,5 +1,7 @@
 #!perl -T
 
+use strict;
+use warnings;
 use Test::More tests => 1;
 
 BEGIN {

--- a/t/01-encoding.t
+++ b/t/01-encoding.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use Test::More;
 
 BEGIN { use_ok( 'Barcode::DataMatrix' ) }


### PR DESCRIPTION
Add `use strict; use warnings;` pragmas where necessary and tell `perlcritic` not to complain on the main module since due to `Any::Moose` these pragmas are already active.