### PR TITLE
Add Perl min version info

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,7 @@ name     'Barcode-DataMatrix';
 all_from 'lib/Barcode/DataMatrix.pm';
 author   q{Mark A. Stratman <stratman@gmail.com>};
 license  'perl';
+perl_version '5.006';
 
 requires 'Any::Moose' => '0.15';
 


### PR DESCRIPTION
This change addresses the missing Perl version warning on CPANTS
(http://cpants.cpanauthors.org/dist/Barcode-DataMatrix).  Setting the
minimum Perl version is considered good practice (see also
http://neilb.org/2015/12/20/specify-perl-version.html).