### PR TITLE
Replace Any::Moose with plain Moose

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ all_from 'lib/Barcode/DataMatrix.pm';
 author   q{Mark A. Stratman <stratman@gmail.com>};
 license  'perl';
 
-requires 'Any::Moose' => '0.15';
+requires 'Moose' => '2.1200';
 
 tests 't/*.t';
 author_tests 'xt';

--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -1,6 +1,6 @@
 package Barcode::DataMatrix;
-use Any::Moose;
-use Any::Moose '::Util::TypeConstraints';
+use Moose;
+use Moose::Util::TypeConstraints;
 use Barcode::DataMatrix::Engine ();
 
 our $VERSION = '0.05';
@@ -138,5 +138,4 @@ See http://dev.perl.org/licenses/ for more information.
 
 =cut
 
-no Any::Moose;
 1; # End of Barcode::DataMatrix


### PR DESCRIPTION
`Any::Moose` is deprecated and thus needs to be replaced.  RT#104920
recommends replacing `Any::Moose` with `Moo` (since `Moo` provides a large
subset of the `Moose` functionality but with a shorter startup time and
lower overhead) however in order to get the enum type constraints working
properly it turned out to be much simpler to simply replace `Any::Moose`
with `Moose` (it was a simple drop-in replacement).  The tests still pass
and it doesn't seem to be any slower than before.  According to
http://shadow.cat/blog/matt-s-trout/moo-versus-any-moose/ it seems that
`Any::Moose` could still load `Moose` anyway (depending upon configuration),
so the replacement implemented here seems like a sensible solution and
resolves the issue in RT#104920.