### PR TITLE
Replace Any::Moose with Moo/Type::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,10 @@ all_from 'lib/Barcode/DataMatrix.pm';
 author   q{Mark A. Stratman <stratman@gmail.com>};
 license  'perl';
 
-requires 'Any::Moose' => '0.15';
+requires 'Moo'             => '0';
+requires 'Type::Tiny'      => '0';
+requires 'Types::Standard' => '0';
+requires 'Type::Utils'     => '0';
 
 tests 't/*.t';
 author_tests 'xt';

--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -1,6 +1,8 @@
 package Barcode::DataMatrix;
-use Any::Moose;
-use Any::Moose '::Util::TypeConstraints';
+use Moo;
+use Type::Tiny;
+use Types::Standard qw(:all);
+use Type::Utils qw(enum);
 use Barcode::DataMatrix::Engine ();
 
 our $VERSION = '0.05';
@@ -8,15 +10,15 @@ our $VERSION = '0.05';
 has 'encoding_mode' => (
     is       => 'ro',
     isa      => enum([qw[ ASCII C40 TEXT BASE256 NONE AUTO ]]),
-    isa      => enum('BCDM_EncodingMode', [qw[ ASCII C40 TEXT BASE256 NONE AUTO ]]),
+    isa      => enum(BCDM_EncodingMode => [qw[ ASCII C40 TEXT BASE256 NONE AUTO ]]),
     required => 1,
     default  => 'AUTO',
     documentation => 'The encoding mode for the data matrix. Can be one of: ASCII C40 TEXT BASE256 NONE AUTO',
 );
 has 'process_tilde' => (
     is       => 'ro',
-    isa      => 'Bool',
-    required => 1,
+    isa      => Bool,
+    required => 0,
     default  => 0,
     documentation => 'Set to true to indicate the tilde character "~" is being used to recognize special characters.',
 );
@@ -138,5 +140,4 @@ See http://dev.perl.org/licenses/ for more information.
 
 =cut
 
-no Any::Moose;
 1; # End of Barcode::DataMatrix


### PR DESCRIPTION
RT#104920 recommends that `Any::Moose` be replaced by `Moo` since
`Any::Moose` is deprecated.  This set of changes implements this with a
combination of `Moo` and `Type::Tiny`.  It was also necessary to make
`process_tilde` no longer a required attribute in order to keep the tests
passing (`t/01-encoding.t` complained about `process_tilde` being a missing
argument); from the code it looks like `process_tilde` doesn't have to be
necessary, hence the rationale for this particular change.  This PR thus
addresses the issue in RT#104920.