### PR TITLE
Remove subroutine prototypes

### DIFF
--- a/lib/Barcode/DataMatrix/CharDataFiller.pm
+++ b/lib/Barcode/DataMatrix/CharDataFiller.pm
@@ -50,7 +50,7 @@ sub corner1 {
     return;
 }
 
-sub corner2($) { #(int i)
+sub corner2 { #(int i)
 	my ($self,$i) = @_;
 	my ($ncol,$nrow) = @$self{qw( ncol nrow )};
     $self->module($nrow - 3, 0, $i, 1);
@@ -64,7 +64,7 @@ sub corner2($) { #(int i)
     return;
 }
 
-sub corner3($) { #(int i)
+sub corner3 { #(int i)
 	my ($self,$i) = @_;
 	my ($ncol,$nrow) = @$self{qw( ncol nrow )};
     $self->module($nrow - 3, 0, $i, 1);
@@ -78,7 +78,7 @@ sub corner3($) { #(int i)
     return;
 }
 
-sub corner4($) { #(int i)
+sub corner4 { #(int i)
 	my ($self,$i) = @_;
 	my ($ncol,$nrow) = @$self{qw( ncol nrow )};
     $self->module($nrow - 1, 0, $i, 1);

--- a/lib/Barcode/DataMatrix/Engine.pm
+++ b/lib/Barcode/DataMatrix/Engine.pm
@@ -23,12 +23,12 @@ our (@GFI,@GFL,%POLY,@FORMATS,@C1);
 *FORMATS = \@Barcode::DataMatrix::Constants::FORMATS;
 *C1      = \@Barcode::DataMatrix::Constants::C1;
 
-sub E_ASCII  () { 0 }
-sub E_C40    () { 1 }
-sub E_TEXT   () { 2 }
-sub E_BASE256() { 3 }
-sub E_NONE   () { 4 }
-sub E_AUTO   () { 5 }
+sub E_ASCII   { 0 }
+sub E_C40     { 1 }
+sub E_TEXT    { 2 }
+sub E_BASE256 { 3 }
+sub E_NONE    { 4 }
+sub E_AUTO    { 5 }
 
 our $N = 255;
 
@@ -36,11 +36,11 @@ sub Types {
 	return qw( ASCII C40 TEXT BASE256 NONE AUTO );
 }
 
-sub stringToType($) {
+sub stringToType {
 	my $m = 'E_'.shift;
 	return eval { __PACKAGE__->$m(); };
 }
-sub typeToString($) {
+sub typeToString {
 	my $i = shift;
 	for (Types) {
 		return $_ if stringToType($_) == $i and defined $i;
@@ -50,7 +50,7 @@ sub typeToString($) {
 
 our @encName = map { typeToString $_ } 0..5;
 
-sub stringToFormat($) {
+sub stringToFormat {
 	my $sz = shift;
 	return unless $sz;
 	my ($w,$h) = map { +int } split /\s*x\s*/,$sz,2;
@@ -177,7 +177,7 @@ sub CalcReed { # (int ai[], int i, int j) : void
 #    return $ai;
 }
 
-sub A253($$) # C8 (int i, int j) : int 
+sub A253 # C8 (int i, int j) : int 
 {
 	my ($i,$j) = @_;
     my $l = $i + (149 * $j) % 253 + 1;
@@ -614,7 +614,7 @@ sub EncodeC40TEXT { # C6 #(int i, int ai[], int ai1[], int ai2[], boolean flag, 
 }
 
 
-sub state255($$) # (int V, int P) : int
+sub state255 # (int V, int P) : int
 {
 	#The 255-state algorithm.
 	#Let P the number of data CWs from the beginning of datas,

--- a/lib/Barcode/DataMatrix/Reed.pm
+++ b/lib/Barcode/DataMatrix/Reed.pm
@@ -11,12 +11,13 @@ our (@GFI,@GFL,%POLY,$DEBUG);
 our $N = 255;
 sub DEBUG () { 0 }
 
-sub mult($$) {
-	return 0 unless $_[0] * $_[1];
-	return $GFI[($GFL[$_[0]] + $GFL[$_[1]]) % $N];
+sub mult {
+    my ($x, $y) = @_;
+	return 0 unless $x * $y;
+	return $GFI[($GFL[$x] + $GFL[$y]) % $N];
 }
 
-sub encode($$) {
+sub encode {
 	my ($ai,$j) = @_;
 	my $i = @$ai;
 	for (0..$#$ai) {


### PR DESCRIPTION
The subroutine prototypes aren't necessary, and where they might have been
ok, they could really be replaced by code which unpacks `@_` appropriately.
This is what this change implements.