### PR TITLE
Update outdated URLs to new locations

### DIFF
--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -108,7 +108,7 @@ L<http://www.idautomation.com/datamatrixfaq.html>
 
 =head1 AUTHORS
 
-Mons Anderson C<< <inthrax@gmail.com> >> (GD::Barcode::DataMatrix at L<http://code.google.com/p/perl-ex/>, from which this distribution originates)
+Mons Anderson C<< <inthrax@gmail.com> >> (GD::Barcode::DataMatrix at L<https://github.com/Mons/perl-ex/>, from which this distribution originates)
 
 Mark A. Stratman, C<< <stratman@gmail.com> >>
 
@@ -124,7 +124,7 @@ L<http://github.com/mstratman/Barcode-DataMatrix>
 
 =item L<HTML::Barcode::DataMatrix>
 
-=item L<http://grandzebu.net/index.php?page=/informatique/codbar-en/datamatrix.htm>
+=item L<http://grandzebu.net/informatique/codbar-en/datamatrix.htm>
 
 =item L<http://www.idautomation.com/datamatrixfaq.html>
 


### PR DESCRIPTION
 - perl-ex Google Code project has moved to GitHub
 - grandzebu's datamatrix page doesn't use php anymore

This commit updates the links in the embedded POD.