### PR TITLE
Remove now unnecessary "no critic" statement

### DIFF
--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -5,7 +5,6 @@ use Types::Standard qw(:all);
 use Type::Utils qw(enum);
 use Barcode::DataMatrix::Engine ();
 
-## no critic (RequireUseWarnings, RequireUseStrict)
 our $VERSION = '0.06';
 
 has 'encoding_mode' => (


### PR DESCRIPTION
This statement is no longer necessary since the distribution now uses `Moo`,
which `perlcritic` recognises as providing the warnings and strict pragmas.