### PR TITLE
Add missing 'use warnings' pragmas

### DIFF
--- a/lib/Barcode/DataMatrix/CharDataFiller.pm
+++ b/lib/Barcode/DataMatrix/CharDataFiller.pm
@@ -1,5 +1,8 @@
 package Barcode::DataMatrix::CharDataFiller;
 
+use strict;
+use warnings;
+
 =head1 Barcode::DataMatrix::CharDataFiller
 
 Handle filling character data within the data matrix array.
@@ -7,10 +10,6 @@ Handle filling character data within the data matrix array.
 The documentation for the methods in this class has been adapted from the
 comments in
 L<https://github.com/itext/itextpdf/blob/master/itext/src/main/java/com/itextpdf/text/pdf/BarcodeDatamatrix.java>.
-
-=cut
-
-use strict;
 
 =head2 new
 

--- a/lib/Barcode/DataMatrix/Engine.pm
+++ b/lib/Barcode/DataMatrix/Engine.pm
@@ -7,6 +7,7 @@ The engine which generates the data matrix bitmap.
 =cut
 
 use strict;
+use warnings;
 no warnings qw(uninitialized);
 use Barcode::DataMatrix::Reed;
 use Barcode::DataMatrix::Constants ();


### PR DESCRIPTION
As noticed on the CPANTS page, the `use warnings` pragma was missing from
two modules.  This patch remedies the issue and should remove the CPANTS
errors.