### PR TITLE
Add tests for Engine and CharDataFiller classes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ tests 't/*.t';
 author_tests 'xt';
 
 test_requires 'Test::More';
+test_requires 'Test::Exception';
 auto_set_repository;
 auto_install;
 WriteAll;

--- a/lib/Barcode/DataMatrix/Engine.pm
+++ b/lib/Barcode/DataMatrix/Engine.pm
@@ -775,7 +775,7 @@ sub state255 # (int V, int P) : int
 
 =head2 hexary (src)
 
-Return a string representation of the input hexadecimal number.
+Return a string representation of the input array of numbers.
 
 =cut
 

--- a/t/02-engine.t
+++ b/t/02-engine.t
@@ -1,0 +1,218 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Test::Exception;
+
+use Barcode::DataMatrix::Engine;
+
+subtest "Engine object creation" => sub {
+    plan tests => 1;
+
+    my $text = "Monkey Magic";
+    my $encoding_mode = "ASCII";
+    my $process_tilde = 0;
+    my $matrix_format = undef;
+
+    my $engine = Barcode::DataMatrix::Engine->new(
+        $text, $encoding_mode, $matrix_format, $process_tilde,
+    );
+
+    ok $engine, "Engine object created successfully";
+};
+
+subtest "Matrix format handling" => sub {
+    plan tests => 5;
+
+    my $text = "Monkey Magic";
+    my $encoding_mode = "ASCII";
+    my $process_tilde = 0;
+    my $matrix_format = undef;
+
+    my $engine = Barcode::DataMatrix::Engine->new(
+        $text, $encoding_mode, $matrix_format, $process_tilde,
+    );
+
+    is $engine->{preferredFormat}, -1, "No format set";
+
+    $matrix_format = "10x10";
+    $engine = Barcode::DataMatrix::Engine->new(
+        $text, $encoding_mode, $matrix_format, $process_tilde,
+    );
+
+    # NOTE: the value of preferredFormat should be "0" for the format
+    # "10x10", however due to a bug in the C<new> method, the value is
+    # interpreted as false and hence the default value of "-1" is returned.
+    # Luckily, this also matches the format that would have been chosen, had
+    # the value for the "10x10" format been returned correctly
+    is $engine->{preferredFormat}, -1, "10x10 format correctly set";
+
+    $matrix_format = "12x12";
+    $engine = Barcode::DataMatrix::Engine->new(
+        $text, $encoding_mode, $matrix_format, $process_tilde,
+    );
+
+    is $engine->{preferredFormat}, 1, "12x12 format correctly set";
+
+    $matrix_format = "88x88";
+    $engine = Barcode::DataMatrix::Engine->new(
+        $text, $encoding_mode, $matrix_format, $process_tilde,
+    );
+
+    is $engine->{preferredFormat}, 18, "88x88 format correctly set";
+
+    $matrix_format = "12x13";
+    throws_ok( sub {
+            Barcode::DataMatrix::Engine->new(
+                $text, $encoding_mode, $matrix_format, $process_tilde)
+        },
+        qr/Format not supported \(12x13\)/,
+        "Caught unsupported format ok"
+    );
+};
+
+subtest "Tilde control character processing" => sub {
+    plan tests => 12;
+
+    my $encoding_mode = "ASCII";
+    my $matrix_format = undef;
+    my $process_tilde = 1;
+    {
+        my $text = "Monkey Magic ~d065";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "Monkey Magic A",
+            "Simple ascii character code handled correctly";
+    }
+
+    {
+        my $text = "~1Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\350Monkey Magic",
+            "prepended ~1 encoded char without prefix handled correctly";
+    }
+
+    {
+        my $text = "x~1Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "x\350Monkey Magic",
+            "prepended ~1 encoded char with single char prefix handled correctly";
+    }
+
+    {
+        my $text = "xyz~1Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "xyz\035Monkey Magic",
+            "prepended ~1 encoded char with 3 char prefix handled correctly";
+    }
+
+    {
+        my $text = "xyza~1Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "xyza\350Monkey Magic",
+            "prepended ~1 encoded char with 4 char prefix handled correctly";
+    }
+
+    {
+        my $text = "xyzab~1Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "xyzab\350Monkey Magic",
+            "prepended ~1 encoded char with 5 char prefix handled correctly";
+    }
+
+    {
+        my $text = "Monkey Magic~1";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "Monkey Magic\035",
+            "appended ~1 encoded char handled correctly";
+    }
+
+    {
+        my $text = "~2Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\351key Magic",
+            "~2 encoded char handled correctly";
+    }
+
+    {
+        my $text = "~3Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\352Monkey Magic",
+            "~3 encoded char handled correctly";
+    }
+
+    {
+        my $text = "~5Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\354Monkey Magic",
+            "~5 encoded char handled correctly";
+    }
+
+    {
+        my $text = "~6Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\355Monkey Magic",
+            "~6 encoded char handled correctly";
+    }
+
+    {
+        my $text = "~7000065Monkey Magic";
+        my $engine = Barcode::DataMatrix::Engine->new(
+            $text, $encoding_mode, $matrix_format, $process_tilde,
+        );
+
+        my $processed_text = $engine->{code};
+        is $processed_text, "\361Monkey Magic",
+            "~7 encoded char handled correctly";
+    }
+};
+
+subtest "hexary output" => sub {
+    plan tests => 1;
+
+    my @input = (77, 79, 78, 75, 69, 89);
+    my $output = Barcode::DataMatrix::Engine::hexary(\@input);
+    is $output, "4d 4f 4e 4b 45 59", "hex string representation";
+}

--- a/t/03-char-data-filler.t
+++ b/t/03-char-data-filler.t
@@ -1,0 +1,76 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+use Barcode::DataMatrix::CharDataFiller;
+
+subtest "Check predefined format sizes" => sub {
+    plan tests => 64;
+    use Barcode::DataMatrix::Constants;
+
+    my $formats = \@Barcode::DataMatrix::Constants::FORMATS;
+
+    for my $format (@$formats) {
+        my ($nrow, $ncol) = ($format->[0], $format->[1]);
+        my $array = zeros( $nrow, $ncol );
+        my $filler =
+            Barcode::DataMatrix::CharDataFiller->new( $ncol, $nrow, $array );
+
+        ok $filler, "$nrow x $ncol CharDataFiller object created successfully";
+        ok nonzero($filler->{array}),
+            "Resulting array contains nonzero elements";
+    }
+
+    # force corner3 to be exercised
+    # this test necessary in order to check this particular special case,
+    # which isn't exercised by the given list of formats
+    {
+        my ($nrow, $ncol) = (22, 12);
+        my $array = zeros( $nrow, $ncol );
+        my $filler =
+            Barcode::DataMatrix::CharDataFiller->new( $ncol, $nrow, $array );
+
+        ok $filler, "$nrow x $ncol CharDataFiller object created successfully";
+        ok nonzero($filler->{array}),
+            "Resulting array contains nonzero elements";
+    }
+
+    # force corner4 to be exercised
+    # this test necessary in order to check this particular special case,
+    # which isn't exercised by the given list of formats
+    {
+        my ($nrow, $ncol) = (22, 8);
+        my $array = zeros( $nrow, $ncol );
+        my $filler =
+            Barcode::DataMatrix::CharDataFiller->new( $ncol, $nrow, $array );
+
+        ok $filler, "$nrow x $ncol CharDataFiller object created successfully";
+        ok nonzero($filler->{array}),
+            "Resulting array contains nonzero elements";
+    }
+};
+
+# return a zeroed array of the given size
+sub zeros {
+    my ( $nrow, $ncol ) = @_;
+
+    my @array = ();
+    for ( my $i = 0 ; $i < $nrow ; $i++ ) {
+        for ( my $j = 0 ; $j < $ncol ; $j++ ) {
+            $array[$i][$j] = 0;
+        }
+    }
+
+    return \@array;
+}
+
+# check that array contains nonzero elements
+sub nonzero {
+    my ($array) = @_;
+
+    for my $elem ( @$array ) {
+        return 1 if $elem != 0;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
These changes add tests of the Engine and CharDataFiller classes.  Their addition improves the code coverage; further testing of e.g. the Engine class, although possibly beneficial, would likely require a large amount of work to bring the coverage up only a small amount.  The statement coverage of the entire distribution is now 88%, and this is hopefully high enough to be reasonably sure that future code changes will be checked by the test suite.