### PR TITLE
Remove unused variable in EncodeBASE256

### DIFF
--- a/lib/Barcode/DataMatrix/Engine.pm
+++ b/lib/Barcode/DataMatrix/Engine.pm
@@ -794,7 +794,6 @@ sub EncodeBASE256 {
 	my ($i,$hint,$src,$stat,$res,$flag) = @_;
     my $j = 0;
     my $xv = [];
-    my $k =
     my $l = $stat->[0];
     my $flag1 = 0;
     my $j1 = 0;


### PR DESCRIPTION
For some reason the code `my $k =` turns up in this routine, and happened to
be noticed while reading the code (because it looked odd).  The value `$k`
is actually assigned the value of the variable assigned on the following
line.  However, the variable `$k` is not used in the routine at all and
hence this bug didn't have an influence on the code overall and thus it can
safely be removed.