### PR TITLE
Allow the matrix size to be set manually.

### DIFF
--- a/lib/Barcode/DataMatrix.pm
+++ b/lib/Barcode/DataMatrix.pm
@@ -10,6 +10,12 @@ has 'encoding_mode' => (
     default  => 'AUTO',
     documentation => 'The encoding mode for the data matrix. Can be one of: ASCII C40 TEXT BASE256 NONE AUTO',
 );
+has 'size' => (
+    is       => 'ro',
+    isa      => sub { my $type = shift; return 1 if defined Barcode::DataMatrix::Engine::stringToFormat $type; return 0; },
+    default  => 'AUTO',
+    documentation => 'The module size for the data matrix. Can be one of: 10x10 12x12 14x14 16x16 18x18 20x20 22x22 24x24 26x26 32x32 36x36 40x40 44x44 48x48 52x52 64x64 72x72 80x80 88x88 96x96 104x104 120x120 132x132 144x144 8x18 8x32 12x26 12x36 16x36 16x48 AUTO',
+);
 has 'process_tilde' => (
     is       => 'ro',
     default  => 0,
@@ -64,7 +70,7 @@ sub barcode {
     my $engine = Barcode::DataMatrix::Engine->new(
         $text,
         $self->encoding_mode,
-        undef, # size
+        $self->size,
         $self->process_tilde,
     );
 
@@ -89,6 +95,11 @@ sub barcode {
 
 The encoding mode for the data matrix. Can be one of:
 C<AUTO> (default), C<ASCII>, C<C40>, C<TEXT>, C<BASE256>, or C<NONE>.
+
+=head2 size
+
+The module size for the data matrix. Can be one of:
+C<AUTO> (default), C<10x10>, C<12x12>, C<14x14>, C<16x16>, C<18x18>, C<20x20>, C<22x22>, C<24x24>, C<26x26>, C<32x32>, C<36x36>, C<40x40>, C<44x44>, C<48x48>, C<52x52>, C<64x64>, C<72x72>, C<80x80>, C<88x88>, C<96x96>, C<104x104>, C<120x120>, C<132x132>, C<144x144>, C<8x18>, C<8x32>, C<12x26>, C<12x36>, C<16x36>, C<16x48>.
 
 =head2 process_tilde
 

--- a/lib/Barcode/DataMatrix/Engine.pm
+++ b/lib/Barcode/DataMatrix/Engine.pm
@@ -130,6 +130,7 @@ Convert a "width x height" format string into an internal format specification.
 sub stringToFormat {
 	my $sz = shift;
 	return unless $sz;
+	return if $sz eq 'AUTO';
 	my ($w,$h) = map { +int } split /\s*x\s*/,$sz,2;
 	my $r;
 	for my $i (0..$#FORMATS) {


### PR DESCRIPTION
Hi, I'm not sure if this is wanted or not, but I had a requirement to use a specific matrix size for a postal carrier's barcode. This diff allows you to do things like this,

`my $code = Barcode::DataMatrix->new(size => "16 x 48")->barcode($_);`